### PR TITLE
Changed header's subLayout alignment

### DIFF
--- a/SimCenterCommon/HeaderWidget.cpp
+++ b/SimCenterCommon/HeaderWidget.cpp
@@ -57,7 +57,11 @@ HeaderWidget::HeaderWidget(QWidget *parent)
     leftLayout->setAlignment(Qt::AlignLeft); //can this be done in CSS???
     leftLayout->addWidget(titleText);
 
-    subLayout->setAlignment(Qt::AlignRight);
+//    commented this out so that in CFDClientProgram/mainWindow/cwe_mainwindow.cpp
+//    we could add the status line to the center by specifying on the new widget
+//    setAlignment(Qt::AlignHCenter) and setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred)
+//    see lines 86-89 of that file
+//    subLayout->setAlignment(Qt::AlignRight);
 
     layout->addLayout(leftLayout);
     layout->addLayout(subLayout);


### PR DESCRIPTION
For use in CFDClientProgram - unsure of potential repercussions in other places where this 'SimCenterCommon' widget is used. 

In CFDClientProgram I specify setAlignment(Qt::AlignHCenter) to place the status line in the center of the header instead of the top right of the header. This was an effort to promote the status line and make it more visible. 